### PR TITLE
Fix returning success despite reporting error

### DIFF
--- a/rgi.xml
+++ b/rgi.xml
@@ -6,7 +6,7 @@
     <stdio>
         <exit_code range="1:" />
     </stdio>
-    <command><![CDATA[
+    <command detect_errors="aggressive"><![CDATA[
 #if $db_opts.db_opts_selector != "default":
     rgi load
         #if $db_opts.db_opts_selector == "local":


### PR DESCRIPTION
The tool currently returns success despite reporting errors:
```
blastp: error while loading shared libraries: libssl.so.1.0.0: cannot open shared object file: No such file or directory
ERROR 2019-09-17 15:02:50,799 : missing blast xml file(/project/6004808/ncm3/galaxy-19.05-git/galaxy-database/jobs_directory/004/4182/working/dataset_5083.dat.temp.contig.fsa.blastRes.xml). Please check if input_type: 'contig' correspond with input file: '/project/rpp-fiona/ncm3/galaxy-19.05-git/galaxy-database/files/005/dataset_5083.dat' or use '--low_quality' flag for short contigs to predicts partial genes.
```