### PR TITLE
Deduplicate database entries

### DIFF
--- a/data_managers/data_manager_rgi_build_db/tool_data_table_conf.xml.sample
+++ b/data_managers/data_manager_rgi_build_db/tool_data_table_conf.xml.sample
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <tables>
     <!-- Locations of RGI database in the required format -->
-    <table name="rgi_databases" comment_char="#">
+    <table name="rgi_databases" comment_char="#" allow_duplicate_entries="False">
         <columns>value, name, path</columns>
         <file path="tool-data/rgi_databases.loc" />
     </table>


### PR DESCRIPTION
Running the data manager multiple times with the same values causes duplicate entries.
I do not believe this is desired behavior.