### PR TITLE
Set tool profile to 18.09

### DIFF
--- a/data_managers/data_manager_rgi_build_db/data_manager/rgi_database_builder.xml
+++ b/data_managers/data_manager_rgi_build_db/data_manager/rgi_database_builder.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="rgi_database_builder" name="RGI Database Builder" tool_type="manage_data" version="1.2.0">
+<tool id="rgi_database_builder" name="RGI Database Builder" profile="18.09" tool_type="manage_data" version="1.2.0">
     <description>Download and build the CARD database for RGI</description>
     <requirements>
 	<requirement type="package" version="5.2.1">rgi</requirement>

--- a/rgi.xml
+++ b/rgi.xml
@@ -1,4 +1,4 @@
-<tool id="rgi" name="Resistance Gene Identifier (RGI)" version="5.2.1">
+<tool id="rgi" name="Resistance Gene Identifier (RGI)" profile="18.09" version="5.2.1">
     <description>This tool predicts resistome(s) from protein or nucleotide data based on homology and SNP models.</description>
     <requirements>
         <requirement type="package" version="5.2.1">rgi</requirement>


### PR DESCRIPTION
Galaxy defaults to running tools without a profile in "legacy mode" which forces the tool to run in the galaxy environment